### PR TITLE
Fix demo software for DMX-TX2 and DMX-FS1

### DIFF
--- a/software/desktop/src/main-process/demo.js
+++ b/software/desktop/src/main-process/demo.js
@@ -35,8 +35,6 @@ app.on('before-quit', () => {
 // Look for tx and rx boards.
 boardEvents.on('board', (board) => {
 
-    console.log('boardEvents callback ', board.path);
-
     // Tx board
     if (board?.boardType == 1 && !currentTxBoard) {
         currentTxBoard = board;

--- a/software/desktop/src/main-process/models/supported-sketches.js
+++ b/software/desktop/src/main-process/models/supported-sketches.js
@@ -28,7 +28,7 @@
     {
         name: 'Frame Scrambler',
         file: 'Scrambler.ino',
-        sketchId: 'Scrambler',
+        sketchId: 'Frame-Scrambler',
         boardType: 3,
     }
  ];

--- a/software/desktop/src/renderer-process/connect.js
+++ b/software/desktop/src/renderer-process/connect.js
@@ -29,6 +29,15 @@ document.addEventListener('readystatechange', (event) => {
     };
 });
 
+// Clear the boards.
+window.configureApi.onAllBoardsError((error) => {
+    clearBoards();
+});
+
+window.configureApi.onAllBoardsList((boards) => {
+    clearBoards();
+});
+
 // Display the boards.
 window.demoApi.onBoardTx((board) => {
     transmitterBoard = board;
@@ -47,6 +56,20 @@ window.demoApi.onBoardFs((board) => {
     refreshConnectFsBoard = !board;
     displayConnection();
 });
+
+/**
+ * Display the connections
+ *
+ */
+function clearBoards() {
+    transmitterBoard = undefined;
+    refreshConnectTxBoard = true;
+    receiverBoard = undefined;
+    refreshConnectRxBoard = true;
+    scramblerBoard = undefined;
+    refreshConnectFsBoard = true;
+    displayConnection();
+}
 
 /**
  * Display the connections

--- a/software/scrambler/PinChange.cpp
+++ b/software/scrambler/PinChange.cpp
@@ -1,7 +1,7 @@
 /**
  * DMX Demonstrator Transmitter pin change library
- * Copyright (C) 2020 Crazy Giraffe Software
- * https://github.com/crazy-giraffe-software/dmxdemonstrator/tree/master/software/transmitter
+ * Copyright (C) 2020 Sparky Bobo Designs
+ * https://github.com/SparkyBobo/dmxdemonstrator/tree/master/software/transmitter
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/software/scrambler/PinChange.h
+++ b/software/scrambler/PinChange.h
@@ -1,7 +1,7 @@
 /**
  * DMX Demonstrator Transmitter pin change library
- * Copyright (C) 2020 Crazy Giraffe Software
- * https://github.com/crazy-giraffe-software/dmxdemonstrator/tree/master/software/transmitter
+ * Copyright (C) 2020 Sparky Bobo Designs
+ * https://github.com/SparkyBobo/dmxdemonstrator/tree/master/software/transmitter
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ class PinChangeInterrupt {
 #elif defined(__AVR_ATmega32U4__)
         PCMSK0 |= (1 << PCINT5); // Pin D9 is PCINT5, D13 has no PCINT assignment.
 #else
-        PCMSK0 |= (1 << PCINT5); // Pin D13 is PCINT5, D9 is PCINT1 (either will work).
+        PCMSK0 |= (1 << PCINT1); // Pin D13 is PCINT5, D9 is PCINT1 (either will work).
 #endif
     }
 

--- a/software/scrambler/README.md
+++ b/software/scrambler/README.md
@@ -16,6 +16,11 @@ The frame scrambler software is an Arduino sketch design for use with the DMX-FS
 
 ## Version History
 
+### Rev 1.1
+
+- Add cr/lf to startup messages so companion software can discover it.
+- Fix issue where scrambler didn't detect tx clock on Uno
+
 ### Rev 1.0
 
 - Initial draft

--- a/software/scrambler/scrambler.ino
+++ b/software/scrambler/scrambler.ino
@@ -25,7 +25,7 @@
   * running any of the supported hardware options. All output options
   * can be used at the same time.
   */
-#define _VERSION_ "1.0"
+#define _VERSION_ "1.1"
 
 /**
  * Local copy of JC_Button: https://github.com/JChristensen/JC_Button
@@ -142,9 +142,9 @@ const char compactDataFormat[] PROGMEM = "m,%s,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,
  * The serial respones and help menu.
  */
 const char newlineMessage[] PROGMEM = "\r\n";
-const char startUpMessage[] PROGMEM = "DMX Demonstrator Frame Scrabmler starting up...";
-const char readyMessage[] PROGMEM = "DMX Demonstrator Frame Scrabmler ready!";
-const char versionFormat[] PROGMEM = "DMX Demonstrator Frame Scrabmler Version %s\r\n";
+const char startUpMessage[] PROGMEM = "DMX Demonstrator Frame-Scrambler starting up...\r\n";
+const char readyMessage[] PROGMEM = "DMX Demonstrator Frame-Scrambler ready!\r\n";
+const char versionFormat[] PROGMEM = "DMX Demonstrator Frame-Scrambler Version %s\r\n";
 const char hardwareDetect[] PROGMEM = "Hardware Detection: found DMX-FS1\r\n";
 
 const char compactStatusFormat[] PROGMEM = "Compact Status: %s\r\n";

--- a/software/transmitter/README.md
+++ b/software/transmitter/README.md
@@ -18,6 +18,10 @@ The transmitter software is an Arduino sketch design for use with the both the D
 
 ### Rev 1.3
 
+- Fix discovery of DMX-TX2
+
+### Rev 1.3
+
 - Added compact status for companion software
 
 ### Rev 1.2

--- a/software/transmitter/transmitter.ino
+++ b/software/transmitter/transmitter.ino
@@ -23,7 +23,7 @@
  * This software supports the Arduio-based DMX Demonstrator Transmitter
  * running any of the supported hardware options.
  */
-#define _VERSION_ "1.3"
+#define _VERSION_ "1.4"
 
 /**
  * Local copy of JC_Button: https://github.com/JChristensen/JC_Button
@@ -88,7 +88,7 @@ int usingControlPro = 0;
 
 const char hardwareDetectFormat[] PROGMEM = "Hardware Detection: found %s\r\n";
 const char hardwareDetectTX1[] PROGMEM = "DMX-TX1";
-const char hardwareDetectTX2[] PROGMEM = "DMX-TX2/DMX-CPB";
+const char hardwareDetectTX2[] PROGMEM = "DMX-TX2";
 const char* const hardwareDetectMessages[] PROGMEM = { hardwareDetectTX1, hardwareDetectTX2, };
 
 /**
@@ -640,6 +640,12 @@ int ReadAnalogCapture(int channel) {
   if (channel == 0) {
     clockValue = analogLevel;
   } else {
+    
+    // Allow value to go to zero
+    // 50 of 1024 is not too much.
+    if (analogLevel < 50) {
+      analogLevel = 0;
+    }
     
     // The DMX-TX2/DMX-CPB has 4 different dimmer levels so read/store using the capture channel.
     // The DMX-TX1 only has a single dimmer level so read/store using the selected channel.


### PR DESCRIPTION
Fix issue where transmitter may not go to 0 when using TX2
Fixed discovery or TX1 and FS1
Fixed bug where FS1 didn't work on Uno
Fixed bug where unplugged device has not handled well. Fix companion bug where connection string did not clear old images